### PR TITLE
SF bugfixes in path_finder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ First stable release.
 #### Removed
 - Removed unnecessary `frag_type` parameter to `Extraction`. Now a class attribute of `GeneralFragment` (and subclasses).
 
+#### Fixed
+- Issues #197: bugs in path-finder found while studying SF excerpt; 
+
 ## [v0.14.1](https://github.com/Luke-Poeppel/decitala/tree/v0.14.1) July 2, 2021
 #### Fixed
 - Fixed a number of typos and added missing examples in `decitala.hm`.


### PR DESCRIPTION
Fixes #197.

- [ ] There's still an onset range bug with split_extractions. See the series of Proceleusmatic in SF1.
- [ ] I added a condition to ensure any remaining sinks that aren't in the path (but still can be) are chosen. But SF1 ignores a viable trochee at the end.
- [ ] It seems like Tribrachs are getting consistently ignored... Probably good idea to add Ditribrach for consitency. Might solve some of this.