### PR TITLE
BROKEN Fixes #217. Schultz contour bugs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ First stable release.
 
 #### Fixed
 - The `return_tonic` parameter for `KS_diatonic` was returning incorrect values.
+- Issues #217: bugs with Schultz contour calculation;
 
 ## [v0.14.1](https://github.com/Luke-Poeppel/decitala/tree/v0.14.1) July 2, 2021
 #### Fixed

--- a/decitala/hm/contour.py
+++ b/decitala/hm/contour.py
@@ -274,27 +274,35 @@ def _get_initial_extrema(contour):
 	return out
 
 def _track_extrema(contour, mode):
+	"""
+	>>> c = [[6, {-1}], [0, {-1}], [7, {1}], [6, {-1}]]
+	>>> _track_extrema(c, mode="max")
+	>>> c
+	[[6, {-1}], [0, {-1}], [7, {1}], [6, {-1}]]
+	"""
 	if mode == "max":
 		check = lambda x: 1 in x[1]
 	else:
 		check = lambda x: -1 in x[1]
 
-	for i, this_window in enumerate(roll_window(array=contour, window_size=3, fn=check)):
-		extrema_tracker = this_window[1][1]
-		if not(extrema_tracker):
-			continue
-		elif None in this_window:
-			continue
-		else:
-			# After level of reduction, the extrema might *say* it's an extrema, but it isn't anymore!
-			# So if it's no longer an extrema, remove it.
-			if _center_of_window_is_extremum(window=this_window, mode=mode):
-				pass
+	windows = roll_window(array=contour, window_size=3, fn=check)
+	for i, this_window in enumerate(windows):
+		if all(x for x in this_window):
+			extrema_tracker = this_window[1][1]
+			if not(extrema_tracker):
+				continue
+			elif None in this_window:
+				continue
 			else:
-				if mode == "max":
-					extrema_tracker.remove(1)
+				# After level of reduction, the extrema might *say* it's an extrema, but it isn't anymore!
+				# So if it's no longer an extrema, remove it.
+				if _center_of_window_is_extremum(window=this_window, mode=mode):
+					pass
 				else:
-					extrema_tracker.remove(-1)
+					if mode == "max":
+						extrema_tracker.remove(1)
+					else:
+						extrema_tracker.remove(-1)
 
 ####################################################################################################
 # Implementation of Morris contour reduction algorithm (1993).

--- a/decitala/hm/contour.py
+++ b/decitala/hm/contour.py
@@ -404,8 +404,8 @@ def _window_has_intervening_extrema(window, contour, mode):
 	... 	(2, [2, {1}]),
 	... 	(4, [2, {1}])
 	... ]
-	>>> contour = [[1, {1, -1}], [0, {-1}], [2, {1}], [0, {-1}], [2, {1}], [1, {1, -1}]]
-	>>> _window_has_intervening_extrema(maxima_group, contour=contour, mode="max")
+	>>> full_contour = [[1, {1, -1}], [0, {-1}], [2, {1}], [0, {-1}], [2, {1}], [1, {1, -1}]]
+	>>> _window_has_intervening_extrema(maxima_group, contour=full_contour, mode="max")
 	True
 	"""
 	for tiny_window in roll_window(window, window_size=2):

--- a/tests/test_contour.py
+++ b/tests/test_contour.py
@@ -127,3 +127,10 @@ class TestLongSchultzContours:
 	def test_b(self):
 		c = [1, 4, 3, 6, 7, 5, 8, 5, 4, 0, 2, 1, 1, 1, 6, 1, 6, 3, 4, 1, 8, 0]
 		assert list(contour.contour_to_schultz_prime_contour(c)[0]) == [1, 1, 2, 0]
+
+# def test_c():
+# 	c = [6, 1, 2, 1, 6, 5, 0, 0, 1, 1, 1, 3, 1, 4, 2, 0, 4, 4]
+# 	res = list(contour.contour_to_schultz_prime_contour(c)[0])
+# 	# assert  == [1, 1, 2, 0]
+
+# print(test_c())

--- a/tests/test_contour.py
+++ b/tests/test_contour.py
@@ -82,42 +82,43 @@ def test_contour_ex15b_schultz():
 	assert list(calculated[0]) == expected
 	assert calculated[1] == expected_depth
 
-def test_alouette_17_schultz():
-	pitches = [73, 89, 86, 75, 75, 75, 75, 75, 75]
-	alouette_17 = [0, 3, 2, 1, 1, 1, 1, 1, 1]
+class TestNightingaleSchultz:
+	def test_nightingale_17_schultz(self):
+		pitches = [73, 89, 86, 75, 75, 75, 75, 75, 75]
+		nightingale_17 = [0, 3, 2, 1, 1, 1, 1, 1, 1]
 
-	assert list(contour.pitch_content_to_contour(pitches)) == alouette_17
+		assert list(contour.pitch_content_to_contour(pitches)) == nightingale_17
 
-	expected = [0, 2, 1]
-	schultz_contour = contour.contour_to_schultz_prime_contour(alouette_17)
-	assert list(schultz_contour[0]) == expected
+		expected = [0, 2, 1]
+		schultz_contour = contour.contour_to_schultz_prime_contour(nightingale_17)
+		assert list(schultz_contour[0]) == expected
 
-def test_alouette_3_schultz():
-	pitches = [68, 68, 79, 68, 68, 74, 66, 68, 81]
-	alouette_3 = [1, 1, 3, 1, 1, 2, 0, 1, 4]
+	def test_nightingale_3_schultz(self):
+		pitches = [68, 68, 79, 68, 68, 74, 66, 68, 81]
+		nightingale_3 = [1, 1, 3, 1, 1, 2, 0, 1, 4]
 
-	expected = [1, 0, 2]
+		expected = [1, 0, 2]
 
-	schultz_contour = contour.contour_to_schultz_prime_contour(alouette_3)
-	assert list(schultz_contour[0]) == expected
+		schultz_contour = contour.contour_to_schultz_prime_contour(nightingale_3)
+		assert list(schultz_contour[0]) == expected
 
-def test_alouette_8_schultz():
-	pitches = [81, 70, 70, 66, 79]
-	alouette_8 = [3, 1, 1, 0, 2, 2, 2, 2]
+	def test_nightingale_8_schultz(self):
+		pitches = [81, 70, 70, 66, 79]
+		nightingale_8 = [3, 1, 1, 0, 2, 2, 2, 2]
 
-	expected = [2, 0, 1]
+		expected = [2, 0, 1]
 
-	schultz_contour = contour.contour_to_schultz_prime_contour(alouette_8)
-	assert list(schultz_contour[0]) == expected
+		schultz_contour = contour.contour_to_schultz_prime_contour(nightingale_8)
+		assert list(schultz_contour[0]) == expected
 
-def test_alouette_9_schultz():
-	pitches = [68, 79, 68, 79, 68, 79, 68, 79, 68, 79, 68, 79]
-	alouette_9 = [0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1]
+	def test_nightingale_9_schultz(self):
+		pitches = [68, 79, 68, 79, 68, 79, 68, 79, 68, 79, 68, 79]
+		nightingale_9 = [0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1]
 
-	expected = [0, 1]
+		expected = [0, 1]
 
-	schultz_contour = contour.contour_to_schultz_prime_contour(alouette_9)
-	assert list(schultz_contour[0]) == expected
+		schultz_contour = contour.contour_to_schultz_prime_contour(nightingale_9)
+		assert list(schultz_contour[0]) == expected
 
 class TestLongSchultzContours:
 	def test_a(self):
@@ -129,8 +130,8 @@ class TestLongSchultzContours:
 		assert list(contour.contour_to_schultz_prime_contour(c)[0]) == [1, 1, 2, 0]
 
 # def test_c():
-# 	c = [6, 1, 2, 1, 6, 5, 0, 0, 1, 1, 1, 3, 1, 4, 2, 0, 4, 4]
+# 	c = [0, 1, 1, 1, 2, 1, 0, 0, 0, 1, 0, 0, 0, 2, 1, 2, 1, 0]
 # 	res = list(contour.contour_to_schultz_prime_contour(c)[0])
-# 	# assert  == [1, 1, 2, 0]
+# # 	# assert  == [1, 1, 2, 0]
 
 # print(test_c())

--- a/tests/test_contour.py
+++ b/tests/test_contour.py
@@ -118,3 +118,12 @@ def test_alouette_9_schultz():
 
 	schultz_contour = contour.contour_to_schultz_prime_contour(alouette_9)
 	assert list(schultz_contour[0]) == expected
+
+class TestLongSchultzContours:
+	def test_a(self):
+		c = [6, 1, 4, 4, 7, 0, 9, 8, 8, 1, 7, 3, 5, 0, 6, 1, 1, 0, 7, 2, 7, 6]
+		assert list(contour.contour_to_schultz_prime_contour(c)[0]) == [1, 0, 2, 1]
+
+	def test_b(self):
+		c = [1, 4, 3, 6, 7, 5, 8, 5, 4, 0, 2, 1, 1, 1, 6, 1, 6, 3, 4, 1, 8, 0]
+		assert list(contour.contour_to_schultz_prime_contour(c)[0]) == [1, 1, 2, 0]


### PR DESCRIPTION
Broken examples
```
[6, 1, 4, 4, 7, 0, 9, 8, 8, 1, 7, 3, 5, 0, 6, 1, 1, 0, 7, 2, 7, 6]
[1, 4, 3, 6, 7, 5, 8, 5, 4, 0, 2, 1, 1, 1, 6, 1, 6, 3, 4, 1, 8, 0]
[4, 7, 7, 0, 0, 6, 0, 5, 5, 1, 1, 0, 7, 3, 0, 0, 2, 5, 1, 0, 5, 0]
[1, 1, 0, 1, 1, 7, 4, 5, 6, 1, 1, 1, 5, 7, 6, 1, 1, 3, 0, 2, 2, 1]
[1, 8, 6, 0, 8, 1, 4, 1, 7, 3, 4, 6, 2, 8, 6, 5, 1, 0]
[1, 4, 3, 1, 4, 2, 0, 1, 4, 6, 1, 6, 5, 5, 1, 1, 1, 1, 1, 4, 6, 4]
[2 3 0 1 1 4 2 0 2 2 3 0 3 3 0 0 4 0]
[2 3 3 0 0 2 4 1 2 0 3 1 0 2 0 4 3 0]
[0 1 1 0 1 2 1 2 0 1 0 0 1 0 0 0 2 1]
[0 1 1 1 2 1 0 0 0 1 0 0 0 2 1 2 1 0]
```

Bug in `_schultz_extrema_check` for the first on second reduction step: 
```
[[6, {-1}], [0, {-1}], [7, {1}], [6, {-1}]]
```